### PR TITLE
Changed default config logic to work with Symfony 3.4

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -407,7 +407,7 @@ final class DefaultConfiguration extends AbstractConfiguration
         // TODO: Be a bit more clever and for example take composer.json extra configuration into account
         if (2 === $symfonyMajorVersion) {
             $this->_symfonyDirectoryStructureVersion = self::SYMFONY_2;
-        } elseif (3 === $symfonyMajorVersion && 4 < $symfonyMinorVersion) {
+        } elseif (3 === $symfonyMajorVersion && 3 < $symfonyMinorVersion) {
             $this->_symfonyDirectoryStructureVersion = self::SYMFONY_3;
         } elseif (4 === $symfonyMajorVersion || (3 === $symfonyMajorVersion && 4 >= $symfonyMinorVersion)) {
             $this->_symfonyDirectoryStructureVersion = self::SYMFONY_4;


### PR DESCRIPTION
The default configuration doesn't work for Symfony 3.4, with this change it will work out of the box.